### PR TITLE
TESTGEN-11 fix some errors

### DIFF
--- a/internal/presenter/factory.go
+++ b/internal/presenter/factory.go
@@ -4,6 +4,7 @@ import (
 	domain "github.com/LaHainee/go_test_template_gen/internal/domain/function"
 	"github.com/LaHainee/go_test_template_gen/internal/model"
 	"github.com/LaHainee/go_test_template_gen/internal/presenter/tests/presenter"
+	"github.com/LaHainee/go_test_template_gen/internal/presenter/tests/presenter/imports"
 	"github.com/LaHainee/go_test_template_gen/internal/presenter/tests/presenter/loop"
 	"github.com/LaHainee/go_test_template_gen/internal/presenter/tests/presenter/structure"
 	sourceLoop "github.com/LaHainee/go_test_template_gen/internal/presenter/tests/source/loop"
@@ -77,6 +78,7 @@ func (f *Factory) mustInitPresenterFunction() {
 			sourceLoop.NewFunctionCall(),
 			sourceLoop.NewExpectationCall(),
 		),
+		imports.NewWithOutMock(),
 	)
 }
 
@@ -93,6 +95,7 @@ func (f *Factory) mustInitPresenterMethodWithoutMocks() {
 			sourceLoop.NewFunctionCall(),
 			sourceLoop.NewExpectationCall(),
 		),
+		imports.NewWithOutMock(),
 	)
 }
 
@@ -111,5 +114,6 @@ func (f *Factory) mustInitPresenterMethodWithMocks() {
 			sourceLoop.NewFunctionCall(),
 			sourceLoop.NewExpectationCall(),
 		),
+		imports.NewWithMock(),
 	)
 }

--- a/internal/presenter/tests/presenter/contract.go
+++ b/internal/presenter/tests/presenter/contract.go
@@ -11,3 +11,7 @@ type structurePresenter interface {
 type loopPresenter interface {
 	Present(function model.Function) string
 }
+
+type importsGetter interface {
+	Get(function model.Function) []string
+}

--- a/internal/presenter/tests/presenter/imports/const.go
+++ b/internal/presenter/tests/presenter/imports/const.go
@@ -1,0 +1,6 @@
+package imports
+
+var defaultImportsList = []string{
+	"\"testing\"",
+	"\"github.com/stretchr/testify/assert\"",
+}

--- a/internal/presenter/tests/presenter/imports/with_mock.go
+++ b/internal/presenter/tests/presenter/imports/with_mock.go
@@ -1,0 +1,25 @@
+package imports
+
+import "github.com/LaHainee/go_test_template_gen/internal/model"
+
+type WithMock struct{}
+
+func NewWithMock() *WithMock {
+	return &WithMock{}
+}
+
+func (i *WithMock) Get(function model.Function) []string {
+	importsList := append(defaultImportsList, "\"github.com/golang/mock/gomock\"")
+
+	if function.Receiver == nil {
+		return importsList
+	}
+
+	for _, dep := range function.Receiver.Dependencies {
+		if dep.IsLogger() {
+			importsList = append(importsList, "\"go.avito.ru/gl/logger/v3\"")
+		}
+	}
+
+	return importsList
+}

--- a/internal/presenter/tests/presenter/imports/without_mock.go
+++ b/internal/presenter/tests/presenter/imports/without_mock.go
@@ -1,0 +1,13 @@
+package imports
+
+import "github.com/LaHainee/go_test_template_gen/internal/model"
+
+type WithOutMock struct{}
+
+func NewWithOutMock() *WithOutMock {
+	return &WithOutMock{}
+}
+
+func (i *WithOutMock) Get(_ model.Function) []string {
+	return defaultImportsList
+}

--- a/internal/presenter/tests/presenter/presenter.go
+++ b/internal/presenter/tests/presenter/presenter.go
@@ -5,12 +5,14 @@ import "github.com/LaHainee/go_test_template_gen/internal/model"
 type Presenter struct {
 	structure structurePresenter
 	loop      loopPresenter
+	imports   importsGetter
 }
 
-func NewPresenter(sp structurePresenter, lp loopPresenter) *Presenter {
+func NewPresenter(sp structurePresenter, lp loopPresenter, ig importsGetter) *Presenter {
 	return &Presenter{
 		structure: sp,
 		loop:      lp,
+		imports:   ig,
 	}
 }
 
@@ -22,11 +24,6 @@ func (p *Presenter) PresentStructure(function model.Function) string {
 	return p.structure.Present(function)
 }
 
-func (p *Presenter) PresentImports(_ model.Function) []string {
-	return []string{
-		"\"context\"",
-		"\"testing\"",
-		"\"github.com/golang/mock/gomock\"",
-		"\"github.com/stretchr/testify/assert\"",
-	}
+func (p *Presenter) PresentImports(function model.Function) []string {
+	return p.imports.Get(function)
 }

--- a/internal/presenter/tests/source/structure/arguments.go
+++ b/internal/presenter/tests/source/structure/arguments.go
@@ -13,12 +13,6 @@ func NewArguments() *Arguments {
 }
 
 func (s *Arguments) Extend(function model.Function) func(structure *test.Structure) {
-	if len(function.InputArguments) == 0 {
-		return func(structure *test.Structure) {
-			structure.FunctionArguments = []test.Statement{}
-		}
-	}
-
 	declarations := make([]test.Statement, 0)
 	declarations = append(declarations, s.getInputArgumentsDeclarations(function)...)
 	declarations = append(declarations, s.getNonInterfaceDependenciesDeclarations(function)...)


### PR DESCRIPTION
Исправил некоторые ошибки
1) У тестовой структуры есть список аргументов даже если у функции нет аргументов на вход (e.g. функция с ресивером ничего не принимает на вход, но у структуры ресивера есть зависимости)
2) Импорт gomock добавляется только если есть что мокать
3) Если в зависимостях есть логгер, то добавляется соответствующий импорт